### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ class Example extends React.Component {
 | name                      | required | default | description | 
 | ------------------------- | -------- | ------- | ------------|
 | snapPoints                | yes      |         | E.g. `[300, 200, 0]`. Points for snapping of bottom sheet coomponent. They define distance from bottom of the screen. Might be number or percent (as string e.g. `'20%'`) for points or percents of screen height from bottom. |
-| initialSnap               | no       |    0    | Determines initial snap point of bottom sheet. |
+| initialSnap               | no       |    0    | Determines initial snap point of bottom sheet. The value is the index from snapPoints. |
 | renderContent             | no       |         | Method for rendering scrollable content of bottom sheet. |
 | renderHeader              | no       |         | Method for rendering non-scrollable header of bottom sheet. |
 | enabledGestureInteraction | no       | `true`  | Defines if bottom sheet could be scrollable by gesture. | 


### PR DESCRIPTION
Make it clear that `initialSnap` value is actually the index from `snapPoints` and not the point value itself.

Example, if `snapPoints=[400,250,50]` and I want to set initial snap point to 250 then the `initialSnap` value is actually 1.