### PR TITLE
If inner scrolling is disabled, leave out content wrapper style

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,12 +437,10 @@ export default class BottomSheetBehavior extends Component {
             </Animated.View>
           </PanGestureHandler>
           <View
-            style={{
+            style={this.props.enabledInnerScrolling && {
               height: this.state.initSnap - this.state.heightOfHeader,
-              overflow: 'hidden'
-            }}
-          >
-
+              overflow: 'hidden',
+            }}>
             <PanGestureHandler
               enabled={this.props.enabledGestureInteraction}
               waitFor={this.master}


### PR DESCRIPTION
This makes it really easy to make a background that continues when you overdrag the sheet. For example:

```jsx
<BottomSheet
  ref={this.sheetRef}
  overdragResistanceFactor={8}
  enabledInnerScrolling={false}
  snapPoints={[300, 0]}
  renderContent={this.renderContent}
  renderHeader={this.renderHeader}
  initialSnap={1}
  callbackNode={this.sheetOpenValue}
/>
```

And in the content:

```jsx
renderContent = () => {
  return (
    <View
      style={{
        padding: 20,
        height: Dimensions.get('window').height,
        backgroundColor: '#fff',
      }}>
      <Text style={{ fontSize: 22 }}>Hello this is some content!</Text>
      <Text style={{ fontSize: 22 }}>More of it here</Text>
      <Text style={{ fontSize: 22, marginTop: 100 }}>And down here</Text>
    </View>
  );
};
```

## Without these changes

![without](https://user-images.githubusercontent.com/90494/54893121-920b5d00-4e71-11e9-845a-6e7bf12e0b1b.gif)

## With these changes

![with](https://user-images.githubusercontent.com/90494/54893131-9c2d5b80-4e71-11e9-8094-89910cbab9a1.gif)
