### PR TITLE
feat: Add a new headerPosition prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ class Example extends React.Component {
 | enabledInnerScrolling     | no       | `true`  | Defines whether it's possible to scroll inner content of bottom sheet. |
 | callbackNode              | no       |         | `reanimated` node which holds position of bottom sheet, where `0` it the highest snap point and `1` is the lowest. |
 | contentPosition           | no       |         | `reanimated` node which holds position of bottom sheet's content (in dp) |
+| headerPosition           | no       |         | `reanimated` node which holds position of bottom sheet's header (in dp) |
 | overdragResistanceFactor  | no       |   0     | `Defines how violently sheet has to stopped while overdragging. 0 means no overdrag |
 | springConfig              | no       | `{ }`   | Overrides config for spring animation |
 | innerGestureHandlerRefs   | no       |         | Refs for gesture handlers used for building bottom sheet. The array consists fo three refs. The first for PanGH used for inner content scrolling. The second for PanGH used for header. The third for TapGH used for stopping scrolling the content.   |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -55,6 +55,11 @@ type Props = {
   contentPosition?: Animated.Value<number>
 
   /**
+   * Reanimated node which holds position of bottom sheet's header (in dp).
+   */
+  headerPosition?: Animated.Value<number>
+
+  /**
    * Defines how violently sheet has to stopped while overdragging. 0 means no overdrag. Defaults to 0.
    */
   overdragResistanceFactor: number
@@ -107,7 +112,7 @@ const magic = {
   restDisplacementThreshold: 0.3,
   deceleration: 0.999,
   bouncyFactor: 1,
-  velocityFactor: P(1, 0.8),
+  velocityFactor: P(1, 1.2),
   toss: 0.4,
   coefForTranslatingVelocities: 5,
 }
@@ -774,6 +779,14 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
                 exec={onChange(
                   this.Y,
                   set(this.props.contentPosition, sub(0, this.Y))
+                )}
+              />
+            )}
+            {this.props.headerPosition && (
+              <Animated.Code
+                exec={onChange(
+                  this.translateMaster,
+                  set(this.props.headerPosition, this.translateMaster)
                 )}
               />
             )}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -112,7 +112,7 @@ const magic = {
   restDisplacementThreshold: 0.3,
   deceleration: 0.999,
   bouncyFactor: 1,
-  velocityFactor: P(1, 1.2),
+  velocityFactor: P(1, 0.8),
   toss: 0.4,
   coefForTranslatingVelocities: 5,
 }


### PR DESCRIPTION
Added a new headerPosition prop that returns the reanimated node to keep track of the current location of the header (in dp). The reason to add this is in reference to issue #54 where I needed to find the current location to implement the said UI functionality.

I am still not sure if the returned value is the right one though since the Y value starts at 0 from the highest snap point in the array. 

So this needs a lot of discussions 😅