### PR TITLE
Add simultaneous handlers prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ class Example extends React.Component {
 | overdragResistanceFactor  | no       |   0     | `Defines how violently sheet has to stopped while overdragging. 0 means no overdrag |
 | springConfig              | no       | `{ }`   | Overrides config for spring animation |
 | innerGestureHandlerRefs   | no       |         | Refs for gesture handlers used for building bottom sheet. The array consists fo three refs. The first for PanGH used for inner content scrolling. The second for PanGH used for header. The third for TapGH used for stopping scrolling the content.   |
+| simultaneousHandlers | no       |         | Accepts a react ref object or an array of refs to handler components. |
 
 
 ## Methods

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,6 +65,11 @@ type Props = {
   overdragResistanceFactor: number
 
   /**
+   * Array of Refs passed to gesture handlers for simultaneous event handling
+   */
+  simultaneousHandlers: Array<React.RefObject<any>> | React.RefObject<any>
+
+  /**
    * Overrides config for spring animation
    */
   springConfig: {
@@ -708,6 +713,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
             waitFor={this.panRef}
             onGestureEvent={this.handleMasterPan}
             onHandlerStateChange={this.handleMasterPan}
+            simultaneousHandlers={this.props.simultaneousHandlers}
           >
             <Animated.View
               style={{
@@ -732,12 +738,14 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
               ref={this.panRef}
               onGestureEvent={this.handlePan}
               onHandlerStateChange={this.handlePan}
+              simultaneousHandlers={this.props.simultaneousHandlers}
             >
               <Animated.View>
                 <TapGestureHandler
                   ref={this.tapRef}
                   enabled={this.props.enabledGestureInteraction}
                   onHandlerStateChange={this.handleTap}
+                  simultaneousHandlers={this.props.simultaneousHandlers}
                 >
                   <Animated.View
                     style={{


### PR DESCRIPTION
Hi! I've faced an issue with Lists inside BottomSheet, and I could not manage to make them work without adding `simultaneousHandlers` to every GH. 
Maybe I misunderstood sth but I've tried to play around with `innerGestureHandlerRefs` but still, I could not make `FlatList` scrollable unless `enabledGestureInteraction` was false.

Expo example with broken and working FlatList: https://snack.expo.io/@dsznajder/bottomsheet-with-flatlist