### PR TITLE
feat: Add support for onOpenStart, onOpenEnd, onCloseStart and onCloseEnd

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ class Example extends React.Component {
 | springConfig              | no       | `{ }`   | Overrides config for spring animation |
 | innerGestureHandlerRefs   | no       |         | Refs for gesture handlers used for building bottom sheet. The array consists fo three refs. The first for PanGH used for inner content scrolling. The second for PanGH used for header. The third for TapGH used for stopping scrolling the content.   |
 | simultaneousHandlers | no       |         | Accepts a react ref object or an array of refs to handler components. |
+| onOpenStart | no       |         | Accepts a function to be called when the bottom sheet starts to open. |
+| onOpenEnd | no       |         | Accepts a function to be called when the bottom sheet is almost fully openned. |
+| onCloseStart | no       |         | Accepts a function to be called when the bottom sheet starts to close. |
+| onCloseEnd | no       |         | Accepts a function to be called when the bottom sheet is almost closing. |
+| callbackThreshold | no       |    0.01     | Accepts a float value from 0 to 1 indicating the percentage (of the gesture movement) when the callbacks are gonna be called. |
 
 
 ## Methods

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,6 +92,12 @@ type Props = {
   ]
 
   enabledImperativeSnapping?: boolean
+
+  onOpenStart?: () => void
+  onOpenEnd?: () => void
+  onCloseStart?: () => void
+  onCloseEnd?: () => void
+  callbackThreshold?: number
 }
 
 type State = {
@@ -163,6 +169,9 @@ const {
   decay,
   Clock,
   lessThan,
+  call,
+  lessOrEq,
+  neq,
 } = Animated
 
 function runDecay(
@@ -280,6 +289,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
       React.createRef(),
       React.createRef(),
     ],
+    callbackThreshold: 0.01,
   }
 
   private decayClock = new Clock()
@@ -300,6 +310,10 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
   private tapRef: React.RefObject<TapGestureHandler>
   private snapPoint: Animated.Node<number>
   private Y: Animated.Node<number>
+  private onOpenStartValue: Animated.Value<number> = new Value(0)
+  private onOpenEndValue: Animated.Value<number> = new Value(0)
+  private onCloseStartValue: Animated.Value<number> = new Value(1)
+  private onCloseEndValue: Animated.Value<number> = new Value(0)
 
   constructor(props: Props) {
     super(props)
@@ -631,7 +645,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     state: State | undefined
   ): State {
     let snapPoints
-    const sortedPropsSnapPints: Array<{
+    const sortedPropsSnapPoints: Array<{
       val: number
       ind: number
     }> = props.snapPoints
@@ -655,29 +669,29 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
       .sort(({ val: a }, { val: b }) => b - a)
     if (state && state.snapPoints) {
       state.snapPoints.forEach((s, i) =>
-        s.setValue(sortedPropsSnapPints[0].val - sortedPropsSnapPints[i].val)
+        s.setValue(sortedPropsSnapPoints[0].val - sortedPropsSnapPoints[i].val)
       )
       snapPoints = state.snapPoints
     } else {
-      snapPoints = sortedPropsSnapPints.map(
-        p => new Value(sortedPropsSnapPints[0].val - p.val)
+      snapPoints = sortedPropsSnapPoints.map(
+        p => new Value(sortedPropsSnapPoints[0].val - p.val)
       )
     }
 
     const propsToNewIndices: { [key: string]: number } = {}
-    sortedPropsSnapPints.forEach(({ ind }, i) => (propsToNewIndices[ind] = i))
+    sortedPropsSnapPoints.forEach(({ ind }, i) => (propsToNewIndices[ind] = i))
 
     const { initialSnap } = props
 
     return {
       init:
-        sortedPropsSnapPints[0].val -
-        sortedPropsSnapPints[propsToNewIndices[initialSnap]].val,
+        sortedPropsSnapPoints[0].val -
+        sortedPropsSnapPoints[propsToNewIndices[initialSnap]].val,
       propsToNewIndices,
       heightOfHeaderAnimated:
         (state && state.heightOfHeaderAnimated) || new Value(0),
       heightOfContent: (state && state.heightOfContent) || new Value(0),
-      initSnap: sortedPropsSnapPints[0].val,
+      initSnap: sortedPropsSnapPoints[0].val,
       snapPoints,
       heightOfHeader: (state && state.heightOfHeader) || 0,
     }
@@ -783,6 +797,130 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
                     )
                   )
                 )}
+              />
+            )}
+            {(this.props.onOpenStart || this.props.onCloseEnd) && (
+              <Animated.Code
+                exec={onChange(this.translateMaster, [
+                  cond(
+                    and(
+                      lessOrEq(
+                        divide(
+                          this.translateMaster,
+                          this.state.snapPoints[
+                            this.state.snapPoints.length - 1
+                          ]
+                        ),
+                        1 - this.props.callbackThreshold
+                      ),
+                      neq(this.onOpenStartValue, 1)
+                    ),
+                    [
+                      call([], () => {
+                        if (this.props.onOpenStart) this.props.onOpenStart()
+                      }),
+                      set(this.onOpenStartValue, 1),
+                      cond(
+                        defined(this.onCloseEndValue),
+                        set(this.onCloseEndValue, 0)
+                      ),
+                    ]
+                  ),
+                ])}
+              />
+            )}
+            {(this.props.onOpenEnd || this.props.onCloseStart) && (
+              <Animated.Code
+                exec={onChange(this.translateMaster, [
+                  cond(
+                    and(
+                      lessOrEq(
+                        divide(
+                          this.translateMaster,
+                          this.state.snapPoints[
+                            this.state.snapPoints.length - 1
+                          ]
+                        ),
+                        this.props.callbackThreshold
+                      ),
+                      neq(this.onOpenEndValue, 1)
+                    ),
+                    [
+                      call([], () => {
+                        if (this.props.onOpenEnd) this.props.onOpenEnd()
+                      }),
+                      set(this.onOpenEndValue, 1),
+                      cond(
+                        defined(this.onCloseStartValue),
+                        set(this.onCloseStartValue, 0)
+                      ),
+                    ]
+                  ),
+                ])}
+              />
+            )}
+            {(this.props.onCloseStart || this.props.onOpenEnd) && (
+              <Animated.Code
+                exec={onChange(this.translateMaster, [
+                  cond(
+                    and(
+                      greaterOrEq(
+                        divide(
+                          this.translateMaster,
+                          this.state.snapPoints[
+                            this.state.snapPoints.length - 1
+                          ]
+                        ),
+                        this.props.callbackThreshold
+                      ),
+                      neq(this.onCloseStartValue, 1)
+                    ),
+                    [
+                      call([], () => {
+                        if (this.props.onCloseStart) this.props.onCloseStart()
+                      }),
+                      set(this.onCloseStartValue, 1),
+                      cond(
+                        defined(this.onCloseStartValue),
+                        set(this.onOpenEndValue, 0)
+                      ),
+                    ]
+                  ),
+                ])}
+              />
+            )}
+            {(this.props.onCloseEnd || this.props.onOpenStart) && (
+              <Animated.Code
+                exec={onChange(this.translateMaster, [
+                  cond(
+                    and(
+                      greaterOrEq(
+                        divide(
+                          this.translateMaster,
+                          this.state.snapPoints[
+                            this.state.snapPoints.length - 1
+                          ]
+                        ),
+                        1 - this.props.callbackThreshold
+                      ),
+                      neq(this.onCloseEndValue, 1)
+                    ),
+                    [
+                      call([], () => {
+                        if (this.props.onCloseEnd) this.props.onCloseEnd()
+                      }),
+                      set(this.onCloseEndValue, 1),
+                      cond(
+                        defined(this.onOpenStartValue),
+                        set(this.onOpenStartValue, 0)
+                      ),
+                      cond(
+                        defined(this.onOpenEndValue),
+                        set(this.onOpenEndValue, 0)
+                      ),
+                    ]
+                  ),
+                ])}
               />
             )}
             {this.props.contentPosition && (


### PR DESCRIPTION
closes #81 

- Exposed `onOpenStart`, `onOpenEnd`, `onCloseStart`, `onCloseEnd` callbacks.
- Exposed `callbackThreshold` so we can control when to call those callbacks.
- Fixed typos.

### I have a question about usability:
When you have a different initialSnap, let's say your bottom sheet starts opened, what do you expect? The `onOpenStart` method called when you start moving or you expect that it should be called only when the bottom sheet is closed and then opened again?

If the second one is the chosen option, it should be a simple fix. I could do the following on the constructor:
```
if(props.snapPoints[props.initialSnap] !== Math.min(...props.snapPoints)){
     this.onOpenStartValue.setValue(1)
}
```

Same for the case when the bottom-sheet starts fully opened. In this case the onOpenEnd won't be called until the `onCloseStart` has been called. The following is a good solution:
```
if(props.snapPoints[props.initialSnap] === Math.max(...props.snapPoints)){
     this.onCloseStartValue.setValue(0)
     this.onOpenEndValue.setValue(1)
}
```

In my opinion this should be the default behaviour. If you guys agree I'm gonna commit those changes. 

Let me know your opinions. Thanks.