### PR TITLE
fix: typescript to ignore `example` folder

### DIFF
--- a/Example/tsconfig.json
+++ b/Example/tsconfig.json
@@ -18,7 +18,10 @@
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
-    "target": "esnext"
+    "target": "esnext",
+    "paths": {
+      "reanimated-bottom-sheet": ["../src/index"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,6 @@
     "paths": {
       "reanimated-bottom-sheet": ["./src/index"]
     }
-  }
+  },
+  "include": ["src"]
 }


### PR DESCRIPTION
Hi @osdnk ,

i notice since my last PR #68, Typescript starts include `Example` folder to the compiled build which breaks the types for this library.

![image](https://user-images.githubusercontent.com/4061838/65423925-8c83d500-de0a-11e9-9c73-88c17fd2fd50.png)

I have fixed this by only include `src` in the `tsconfig.json`.

Thanks 