### PR TITLE
feat: add bottom clamp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ class Example extends React.Component {
 | enabledHeaderGestureInteraction | no       | `true`  | Defines if bottom sheet header could be scrollable by gesture. |
 | enabledContentGestureInteraction | no       | `true`  | Defines if bottom sheet content could be scrollable by gesture. |
 | enabledManualSnapping     | no       | `true`  | If `false` blocks snapping using `snapTo` method. |
+| enabledBottomClamp        | no       | `false` | If `true` block movement is clamped from bottom to minimal snappoint. |
 | enabledInnerScrolling     | no       | `true`  | Defines whether it's possible to scroll inner content of bottom sheet. |
 | callbackNode              | no       |         | `reanimated` node which holds position of bottom sheet, where `0` it the highest snap point and `1` is the lowest. |
 | contentPosition           | no       |         | `reanimated` node which holds position of bottom sheet's content (in dp) |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -324,7 +324,6 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
   private snapPoint: Animated.Node<number>
   private Y: Animated.Node<number>
   private clampingValue: Animated.Value<number> = new Value(0)
-  private clampingEnabled: Animated.Value<number> = new Value(0)
   private onOpenStartValue: Animated.Value<number> = new Value(0)
   private onOpenEndValue: Animated.Value<number> = new Value(0)
   private onCloseStartValue: Animated.Value<number> = new Value(1)
@@ -367,8 +366,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     this.snapPoint = currentSnapPoint()
 
     if (props.enabledBottomClamp) {
-      this.clampingEnabled.setValue(1);
-      this.clampingValue.setValue(snapPoints[snapPoints.length - 1]);
+      this.clampingValue.setValue(snapPoints[snapPoints.length - 1])
     }
 
     const masterClock = new Clock()
@@ -421,7 +419,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
         greaterThan(masterOffseted, snapPoints[0]),
         cond(
           and(
-            this.clampingEnabled,
+            props.enabledBottomClamp ? 1 : 0,
             greaterThan(masterOffseted, this.clampingValue)
           ),
           this.clampingValue,
@@ -454,12 +452,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props, prevState: State) {
     const { snapPoints } = this.state
-    const { enabledBottomClamp} = this.props;
-
-    if (enabledBottomClamp !== prevProps.enabledBottomClamp) {
-      this.clampingEnabled.setValue(enabledBottomClamp ? 1 : 0)
-    }
-    if (enabledBottomClamp && snapPoints !== prevState.snapPoints) {
+    if (this.props.enabledBottomClamp && snapPoints !== prevState.snapPoints) {
       this.clampingValue.setValue(snapPoints[snapPoints.length - 1])
     }
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -450,7 +450,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     )
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate(_prevProps: Props, prevState: State) {
     const { snapPoints } = this.state
     if (this.props.enabledBottomClamp && snapPoints !== prevState.snapPoints) {
       this.clampingValue.setValue(snapPoints[snapPoints.length - 1])

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -317,13 +317,14 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
   private preventDecaying: Animated.Value<number> = new Value(0)
   private dragMasterY = new Value(0)
   private dragY = new Value(0)
-  private clampingY = new Value(0)
   private translateMaster: Animated.Node<number>
   private panRef: React.RefObject<PanGestureHandler>
   private master: React.RefObject<PanGestureHandler>
   private tapRef: React.RefObject<TapGestureHandler>
   private snapPoint: Animated.Node<number>
   private Y: Animated.Node<number>
+  private clampingValue: Animated.Value<number> = new Value(0)
+  private clampingEnabled: Animated.Value<number> = new Value(0)
   private onOpenStartValue: Animated.Value<number> = new Value(0)
   private onOpenEndValue: Animated.Value<number> = new Value(0)
   private onCloseStartValue: Animated.Value<number> = new Value(1)
@@ -364,8 +365,10 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
           )
     // current snap point desired
     this.snapPoint = currentSnapPoint()
+
     if (props.enabledBottomClamp) {
-      this.clampingY.setValue(snapPoints[snapPoints.length - 1]);
+      this.clampingEnabled.setValue(1);
+      this.clampingValue.setValue(snapPoints[snapPoints.length - 1]);
     }
 
     const masterClock = new Clock()
@@ -418,10 +421,10 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
         greaterThan(masterOffseted, snapPoints[0]),
         cond(
           and(
-            props.enabledBottomClamp ? 1 : 0,
-            greaterThan(masterOffseted, this.clampingY)
+            this.clampingEnabled,
+            greaterThan(masterOffseted, this.clampingValue)
           ),
-          this.clampingY,
+          this.clampingValue,
           masterOffseted
         ),
         max(
@@ -449,10 +452,15 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     )
   }
 
-  componentDidUpdate(_, prevState) {
-    const { snapPoints } = this.state;
-    if (this.props.enabledBottomClamp && snapPoints !== prevState.snapPoints) {
-      this.clampingY.setValue(snapPoints[snapPoints.length - 1]);
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    const { snapPoints } = this.state
+    const { enabledBottomClamp} = this.props;
+
+    if (enabledBottomClamp !== prevProps.enabledBottomClamp) {
+      this.clampingEnabled.setValue(enabledBottomClamp ? 1 : 0)
+    }
+    if (enabledBottomClamp && snapPoints !== prevState.snapPoints) {
+      this.clampingValue.setValue(snapPoints[snapPoints.length - 1])
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,6 +42,11 @@ type Props = {
   enabledContentTapInteraction?: boolean
 
   /**
+   * When true, clamp bottom position to first snapPoint.
+   */
+  enabledBottomClamp?: boolean
+
+  /**
    * If false blocks snapping using snapTo method. Defaults to true.
    */
   enabledManualSnapping?: boolean
@@ -286,6 +291,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     initialSnap: 0,
     enabledImperativeSnapping: true,
     enabledGestureInteraction: true,
+    enabledBottomClamp: false,
     enabledHeaderGestureInteraction: true,
     enabledContentGestureInteraction: true,
     enabledContentTapInteraction: true,
@@ -406,7 +412,14 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
       ),
       cond(
         greaterThan(masterOffseted, snapPoints[0]),
-        masterOffseted,
+        cond(
+          and(
+            props.enabledBottomClamp ? 1 : 0,
+            greaterThan(masterOffseted, snapPoints[snapPoints.length - 1])
+          ),
+          snapPoints[snapPoints.length - 1],
+          masterOffseted
+        ),
         max(
           multiply(
             sub(


### PR DESCRIPTION
If `enabledBottomClamp` is set to true, user is not able to overdrag panel above its minimal snappoint value, so panel behaves like the one from original Apple Maps app.

How it looks like?

![2019-10-16 20 03 39](https://user-images.githubusercontent.com/33039909/66945897-20367300-f050-11e9-9783-470b59271e8d.gif)
