### PR TITLE
fix: snapTo inside sheet content android

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -374,7 +374,10 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     const wasRun: Animated.Value<number> = new Value(0)
     this.translateMaster = block([
       cond(
-        eq(this.panMasterState, GestureState.END),
+        or(
+          eq(this.panMasterState, GestureState.END),
+          eq(this.panMasterState, GestureState.CANCELLED)
+        ),
         [
           set(prevMasterDrag, 0),
           cond(


### PR DESCRIPTION
Hi, as many folks here I was facing an issue with using `snapTo` on touchable element inside sheet content. In my case, it was a button based on `TouchableOpacity`. 

After a few hours of debugging, I found that on Android whenever any touchable element inside sheet is beeing touched `this.panMasterState` is not `END` but `CANCELLED`. That's why `cond` that should start spring animation is not evet evaluated. 

I think this closes at least #76 #16 #69