### PR TITLE
fix: height changes not evaluated

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -663,7 +663,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     nativeEvent: {
       layout: { height },
     },
-  }: LayoutChangeEvent) => this.height.setValue(height)
+  }: LayoutChangeEvent) => requestAnimationFrame(() => this.height.setValue(height))
 
   private handleLayoutContent = ({
     nativeEvent: {


### PR DESCRIPTION
I'm having intermittent issues with the bottom sheet not appearing.

I tracked the issue down to the `height` field. The onLayout callback (`handleFullHeader`) is triggered with the correct dimensions and the `height` AnimatedValue is updated, but the nodes that use this value (opacity/translateY) are never re-evaluated unless something else triggers a re-render.

This diff seems to fix the problem, although I'm not sure why.

I did also try replacing the callback with `Animated.event()` but this does not seem to work (https://github.com/software-mansion/react-native-reanimated/issues/79).

So far I have only seen this issue on Android. Using Expo 35 / react-native-reanimated 1.2.0.