### PR TITLE
feat: enabledBottomInitialAnimation prop added

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ class Example extends React.Component {
 | enabledContentGestureInteraction | no       | `true`  | Defines if bottom sheet content could be scrollable by gesture. |
 | enabledContentTapInteraction | no       | `true`  | Defines whether bottom sheet content could be tapped. |
 | enabledManualSnapping     | no       | `true`  | If `false` blocks snapping using `snapTo` method. |
-| enabledBottomClamp        | no       | `false` | If `true` block movement is clamped from bottom to minimal snappoint. |
+| enabledBottomClamp        | no       | `false` | If `true` block movement is clamped from bottom to minimal snapPoint. |
+| enabledBottomInitialAnimation        | no       | `false` | If `true` sheet will grows up from bottom to initial snapPoint. |
 | enabledInnerScrolling     | no       | `true`  | Defines whether it's possible to scroll inner content of bottom sheet. |
 | callbackNode              | no       |         | `reanimated` node which holds position of bottom sheet, where `0` it the highest snap point and `1` is the lowest. |
 | contentPosition           | no       |         | `reanimated` node which holds position of bottom sheet's content (in dp) |

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -47,6 +47,11 @@ type Props = {
   enabledBottomClamp?: boolean
 
   /**
+   * When true, sheet will grows up from bottom to initial snapPoint.
+   */
+  enabledBottomInitialAnimation?: boolean
+
+  /**
    * If false blocks snapping using snapTo method. Defaults to true.
    */
   enabledManualSnapping?: boolean
@@ -293,6 +298,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     enabledImperativeSnapping: true,
     enabledGestureInteraction: true,
     enabledBottomClamp: false,
+    enabledBottomInitialAnimation: false,
     enabledHeaderGestureInteraction: true,
     enabledContentGestureInteraction: true,
     enabledContentTapInteraction: true,
@@ -719,10 +725,19 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
 
     const { initialSnap } = props
 
+    let init =
+      sortedPropsSnapPoints[0].val -
+      sortedPropsSnapPoints[propsToNewIndices[initialSnap]].val
+
+    if (props.enabledBottomInitialAnimation) {
+      init =
+        sortedPropsSnapPoints[
+          sortedPropsSnapPoints.length - 1 - propsToNewIndices[initialSnap]
+        ].val
+    }
+
     return {
-      init:
-        sortedPropsSnapPoints[0].val -
-        sortedPropsSnapPoints[propsToNewIndices[initialSnap]].val,
+      init,
       propsToNewIndices,
       heightOfHeaderAnimated:
         (state && state.heightOfHeaderAnimated) || new Value(0),


### PR DESCRIPTION
If `true` sheet will grows up from bottom to initial snapPoint.