### PR TITLE
Added renderBackground option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "reanimated-bottom-sheet",
-  "version": "1.0.0-alpha.22",
+  "name": "@skyraptor/reanimated-bottom-sheet",
+  "version": "1.0.0-alpha.25",
   "description": "Bottom sheet component",
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -30,6 +30,11 @@ type Props = {
   renderHeader?: () => React.ReactNode
 
   /**
+   * Method for rendering background elements of bottom sheet.
+   */
+  renderBackground?: () => React.ReactNode
+
+  /**
    * Defines if bottom sheet could be scrollable by gesture. Defaults to true.
    */
   enabledGestureInteraction?: boolean
@@ -849,6 +854,13 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
               }
             }
           >
+            {this.props.renderBackground && (
+              <View style={{position: 'absolute', flex: 1, top: 0, zIndex: -1}}>
+                {() => {
+                  return this.renderBackground();
+                }}
+              </View>
+            )}
             <PanGestureHandler
               enabled={
                 this.props.enabledGestureInteraction &&
@@ -1060,5 +1072,16 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
         </Animated.View>
       </>
     )
+  }
+
+  renderBackground() {
+    if (this.props.renderBackground) {
+      console.log('BottomSheet renderBackground()');
+      return this.props.renderBackground();
+    } else {
+      console.log('BottomSheet NO renderBackground');
+    }
+
+    return null;
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -856,9 +856,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
           >
             {this.props.renderBackground && (
               <View style={{position: 'absolute', flex: 1, top: 0, zIndex: -1}}>
-                {() => {
-                  return this.renderBackground();
-                }}
+                {this.props.renderBackground()}
               </View>
             )}
             <PanGestureHandler
@@ -1072,16 +1070,5 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
         </Animated.View>
       </>
     )
-  }
-
-  renderBackground() {
-    if (this.props.renderBackground) {
-      console.log('BottomSheet renderBackground()');
-      return this.props.renderBackground();
-    } else {
-      console.log('BottomSheet NO renderBackground');
-    }
-
-    return null;
   }
 }


### PR DESCRIPTION
**Added the renderBackground option.**

This option allows to put any element produced by a render callback behind the scrollable area.
This can be helpful and should be used in situations where you can not use style properties.
I am using it to create a fixed background from an SVG.

```jsx
...
renderBackground={this.renderBackground}
...
```

**Todo**
- [x] Implement it
- [ ] Update documentation
