### PR TITLE
Fix: Change snapTo to snapToIndex to avoid confusion

### DIFF
--- a/Example/Imperative.js
+++ b/Example/Imperative.js
@@ -47,25 +47,25 @@ export default class Example extends React.Component {
         >
           <TouchableOpacity
             style={styles.commandButton}
-            onPress={() => this.bs.current.snapTo(0)}
+            onPress={() => this.bs.current.snapToIndex(0)}
           >
             <Text style={styles.panelButtonTitle}>1</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.commandButton}
-            onPress={() => this.bs.current.snapTo(1)}
+            onPress={() => this.bs.current.snapToIndex(1)}
           >
             <Text style={styles.panelButtonTitle}>2</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.commandButton}
-            onPress={() => this.bs.current.snapTo(2)}
+            onPress={() => this.bs.current.snapToIndex(2)}
           >
             <Text style={styles.panelButtonTitle}>3</Text>
           </TouchableOpacity>
           <TouchableOpacity
             style={styles.commandButton}
-            onPress={() => this.bs.current.snapTo(3)}
+            onPress={() => this.bs.current.snapToIndex(3)}
           >
             <Text style={styles.panelButtonTitle}>4</Text>
           </TouchableOpacity>

--- a/Example/Map.js
+++ b/Example/Map.js
@@ -15,7 +15,7 @@ export default class Example extends React.Component {
       <TextInput
         style={styles.search}
         onFocus={() => {
-          this.bs.current.snapTo(1)
+          this.bs.current.snapToIndex(1)
         }}
         placeholder="search"
       />
@@ -56,7 +56,9 @@ export default class Example extends React.Component {
           renderHeader={this.renderHeader}
           initialSnap={1}
         />
-        <TouchableWithoutFeedback onPress={() => this.bs.current.snapTo(0)}>
+        <TouchableWithoutFeedback
+          onPress={() => this.bs.current.snapToIndex(0)}
+        >
           <Image style={styles.map} source={require('./assets/map-bg.jpg')} />
         </TouchableWithoutFeedback>
       </View>

--- a/Example/Test.js
+++ b/Example/Test.js
@@ -38,16 +38,16 @@ export default class Example extends React.Component {
           renderContent={this.renderInner}
           renderHeader={this.renderHeader}
         />
-        <Button onPress={() => this.bs.current.snapTo(0)} title="0" />
-        <Button onPress={() => this.bs.current.snapTo(1)} title="1" />
+        <Button onPress={() => this.bs.current.snapToIndex(0)} title="0" />
+        <Button onPress={() => this.bs.current.snapToIndex(1)} title="1" />
         <Button
-          onPress={() => this.bs.current.snapTo(2)}
+          onPress={() => this.bs.current.snapToIndex(2)}
           style={{
             zIndex: 0,
           }}
           title="2"
         />
-        <Button onPress={() => this.bs.current.snapTo(3)} title="3" />
+        <Button onPress={() => this.bs.current.snapToIndex(3)} title="3" />
       </View>
     )
   }

--- a/Example/src/screen/AppleMusic.tsx
+++ b/Example/src/screen/AppleMusic.tsx
@@ -69,11 +69,11 @@ const AppleMusic = () => {
   })
 
   const onFlatListTouchStart = () => {
-    bottomSheetRef.current!.snapTo(0)
+    bottomSheetRef.current!.snapToIndex(0)
   }
 
   const onHeaderPress = () => {
-    bottomSheetRef.current!.snapTo(1)
+    bottomSheetRef.current!.snapToIndex(1)
   }
 
   const renderContent = () => {
@@ -116,9 +116,9 @@ const AppleMusic = () => {
           </View>
 
           <Text style={styles.songTitleLarge}>{song.name}</Text>
-          <Text style={styles.songInfoText}>{`${song.artist} ⏤ ${
-            song.album
-          }`}</Text>
+          <Text
+            style={styles.songInfoText}
+          >{`${song.artist} ⏤ ${song.album}`}</Text>
         </AnimatedView>
       </AnimatedView>
     )

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Reanimated Bottom Sheet
+
 Highly configurable component imitating [native bottom sheet behavior](https://material.io/design/components/sheets-bottom.html#standard-bottom-sheet), with fully native 60 FPS animations!
 
 Built from scratch with [react-native-gesture-handler](https://github.com/kmagiera/react-native-gesture-handler) and [react-native-reanimated](https://github.com/kmagiera/react-native-reanimated).
 
 Usable with Expo with no extra native dependencies!
 
-![](gifs/1.gif)  |  ![](gifs/2.gif) |  ![](gifs/3.gif)  |  ![](gifs/4.gif)  |
-:---------------:|:----------------:|:-----------------:|:-----------------:|
-
+| ![](gifs/1.gif) | ![](gifs/2.gif) | ![](gifs/3.gif) | ![](gifs/4.gif) |
+| :-------------: | :-------------: | :-------------: | :-------------: |
 
 ## Installation
 
@@ -48,10 +48,10 @@ We're done! Now you can build and run the app on your device/simulator.
 ## Usage
 
 ```javascript
-import * as React from 'react';
-import { StyleSheet, Text, View, Button } from 'react-native';
-import Animated from 'react-native-reanimated';
-import BottomSheet from 'reanimated-bottom-sheet';
+import * as React from 'react'
+import { StyleSheet, Text, View, Button } from 'react-native'
+import Animated from 'react-native-reanimated'
+import BottomSheet from 'reanimated-bottom-sheet'
 
 export default function App() {
   const renderContent = () => (
@@ -64,9 +64,9 @@ export default function App() {
     >
       <Text>Swipe down to close</Text>
     </View>
-  );
+  )
 
-  const sheetRef = React.useRef(null);
+  const sheetRef = React.useRef(null)
 
   return (
     <>
@@ -80,7 +80,7 @@ export default function App() {
       >
         <Button
           title="Open Bottom Sheet"
-          onPress={() => sheetRef.current.snapTo(0)}
+          onPress={() => sheetRef.current.snapToIndex(0)}
         />
       </View>
       <BottomSheet
@@ -90,50 +90,49 @@ export default function App() {
         renderContent={renderContent}
       />
     </>
-  );
+  )
 }
 ```
 
 ## Props
 
-| name                      | required | default | description |
-| ------------------------- | -------- | ------- | ------------|
-| snapPoints                | yes      |         | E.g. `[300, 200, 0]`. Points for snapping of bottom sheet coomponent. They define distance from bottom of the screen. Might be number or percent (as string e.g. `'20%'`) for points or percents of screen height from bottom. Note: Array values must be in descending order. |
-| initialSnap               | no       |    0    | Determines initial snap point of bottom sheet. The value is the index from snapPoints. |
-| renderContent             | no       |         | Method for rendering scrollable content of bottom sheet. |
-| renderHeader              | no       |         | Method for rendering non-scrollable header of bottom sheet. |
-| enabledGestureInteraction | no       | `true`  | Defines if bottom sheet could be scrollable by gesture. |
-| enabledHeaderGestureInteraction | no       | `true`  | Defines if bottom sheet header could be scrollable by gesture. |
-| enabledContentGestureInteraction | no       | `true`  | Defines if bottom sheet content could be scrollable by gesture. |
-| enabledContentTapInteraction | no       | `true`  | Defines whether bottom sheet content could be tapped. **Note:** If you use `Touchable*` components inside your `renderContent`, you'll have to switch this to `false` to make handlers like `onPress` work. (See [this comment](https://github.com/osdnk/react-native-reanimated-bottom-sheet/issues/219#issuecomment-625894292).) |
-| enabledManualSnapping     | no       | `true`  | If `false` blocks snapping using `snapTo` method. |
-| enabledBottomClamp        | no       | `false` | If `true` block movement is clamped from bottom to minimal snapPoint. |
-| enabledBottomInitialAnimation        | no       | `false` | If `true` sheet will grows up from bottom to initial snapPoint. |
-| enabledInnerScrolling     | no       | `true`  | Defines whether it's possible to scroll inner content of bottom sheet. |
-| callbackNode              | no       |         | `reanimated` node which holds position of bottom sheet, where `0` it the highest snap point and `1` is the lowest. |
-| contentPosition           | no       |         | `reanimated` node which holds position of bottom sheet's content (in dp) |
-| headerPosition           | no       |         | `reanimated` node which holds position of bottom sheet's header (in dp) |
-| overdragResistanceFactor  | no       |   0     | `Defines how violently sheet has to stopped while overdragging. 0 means no overdrag |
-| springConfig              | no       | `{ }`   | Overrides config for spring animation |
-| innerGestureHandlerRefs   | no       |         | Refs for gesture handlers used for building bottom sheet. The array consists fo three refs. The first for PanGH used for inner content scrolling. The second for PanGH used for header. The third for TapGH used for stopping scrolling the content.   |
-| simultaneousHandlers | no       |         | Accepts a react ref object or an array of refs to handler components. |
-| onOpenStart | no       |         | Accepts a function to be called when the bottom sheet starts to open. |
-| onOpenEnd | no       |         | Accepts a function to be called when the bottom sheet is almost fully openned. |
-| onCloseStart | no       |         | Accepts a function to be called when the bottom sheet starts to close. |
-| onCloseEnd | no       |         | Accepts a function to be called when the bottom sheet is almost closing. |
-| callbackThreshold | no       |    0.01     | Accepts a float value from 0 to 1 indicating the percentage (of the gesture movement) when the callbacks are gonna be called. |
-| borderRadius | no       |        | Border radius of content wrapper (excluding header) |
-
+| name                             | required | default | description                                                                                                                                                                                                                                                                                                                        |
+| -------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| snapPoints                       | yes      |         | E.g. `[300, 200, 0]`. Points for snapping of bottom sheet coomponent. They define distance from bottom of the screen. Might be number or percent (as string e.g. `'20%'`) for points or percents of screen height from bottom. Note: Array values must be in descending order.                                                     |
+| initialSnap                      | no       | 0       | Determines initial snap point of bottom sheet. The value is the index from snapPoints.                                                                                                                                                                                                                                             |
+| renderContent                    | no       |         | Method for rendering scrollable content of bottom sheet.                                                                                                                                                                                                                                                                           |
+| renderHeader                     | no       |         | Method for rendering non-scrollable header of bottom sheet.                                                                                                                                                                                                                                                                        |
+| enabledGestureInteraction        | no       | `true`  | Defines if bottom sheet could be scrollable by gesture.                                                                                                                                                                                                                                                                            |
+| enabledHeaderGestureInteraction  | no       | `true`  | Defines if bottom sheet header could be scrollable by gesture.                                                                                                                                                                                                                                                                     |
+| enabledContentGestureInteraction | no       | `true`  | Defines if bottom sheet content could be scrollable by gesture.                                                                                                                                                                                                                                                                    |
+| enabledContentTapInteraction     | no       | `true`  | Defines whether bottom sheet content could be tapped. **Note:** If you use `Touchable*` components inside your `renderContent`, you'll have to switch this to `false` to make handlers like `onPress` work. (See [this comment](https://github.com/osdnk/react-native-reanimated-bottom-sheet/issues/219#issuecomment-625894292).) |
+| enabledManualSnapping            | no       | `true`  | If `false` blocks snapping using `snapToIndex` method.                                                                                                                                                                                                                                                                             |
+| enabledBottomClamp               | no       | `false` | If `true` block movement is clamped from bottom to minimal snapPoint.                                                                                                                                                                                                                                                              |
+| enabledBottomInitialAnimation    | no       | `false` | If `true` sheet will grows up from bottom to initial snapPoint.                                                                                                                                                                                                                                                                    |
+| enabledInnerScrolling            | no       | `true`  | Defines whether it's possible to scroll inner content of bottom sheet.                                                                                                                                                                                                                                                             |
+| callbackNode                     | no       |         | `reanimated` node which holds position of bottom sheet, where `0` it the highest snap point and `1` is the lowest.                                                                                                                                                                                                                 |
+| contentPosition                  | no       |         | `reanimated` node which holds position of bottom sheet's content (in dp)                                                                                                                                                                                                                                                           |
+| headerPosition                   | no       |         | `reanimated` node which holds position of bottom sheet's header (in dp)                                                                                                                                                                                                                                                            |
+| overdragResistanceFactor         | no       | 0       | `Defines how violently sheet has to stopped while overdragging. 0 means no overdrag                                                                                                                                                                                                                                                |
+| springConfig                     | no       | `{ }`   | Overrides config for spring animation                                                                                                                                                                                                                                                                                              |
+| innerGestureHandlerRefs          | no       |         | Refs for gesture handlers used for building bottom sheet. The array consists fo three refs. The first for PanGH used for inner content scrolling. The second for PanGH used for header. The third for TapGH used for stopping scrolling the content.                                                                               |
+| simultaneousHandlers             | no       |         | Accepts a react ref object or an array of refs to handler components.                                                                                                                                                                                                                                                              |
+| onOpenStart                      | no       |         | Accepts a function to be called when the bottom sheet starts to open.                                                                                                                                                                                                                                                              |
+| onOpenEnd                        | no       |         | Accepts a function to be called when the bottom sheet is almost fully openned.                                                                                                                                                                                                                                                     |
+| onCloseStart                     | no       |         | Accepts a function to be called when the bottom sheet starts to close.                                                                                                                                                                                                                                                             |
+| onCloseEnd                       | no       |         | Accepts a function to be called when the bottom sheet is almost closing.                                                                                                                                                                                                                                                           |
+| callbackThreshold                | no       | 0.01    | Accepts a float value from 0 to 1 indicating the percentage (of the gesture movement) when the callbacks are gonna be called.                                                                                                                                                                                                      |
+| borderRadius                     | no       |         | Border radius of content wrapper (excluding header)                                                                                                                                                                                                                                                                                |
 
 ## Methods
 
-### `snapTo(index)`
+### `snapToIndex(index)`
 
 Imperative method on for snapping to snap point in given index. E.g.
 
 ```javascript
 // Snap to the snap point at index 0 (e.g. 450 in [450, 300, 0])
-this.bottomSheetRef.current.snapTo(0)
+this.bottomSheetRef.current.snapToIndex(0)
 ```
 
 Here `this.bottomSheetRef` refers [to the `ref`](https://reactjs.org/docs/react-api.html#reactcreateref) passed to the `BottomSheet` component.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -52,7 +52,7 @@ type Props = {
   enabledBottomInitialAnimation?: boolean
 
   /**
-   * If false blocks snapping using snapTo method. Defaults to true.
+   * If false blocks snapping using snapToIndex method. Defaults to true.
    */
   enabledManualSnapping?: boolean
 
@@ -680,7 +680,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
     ])
   }
 
-  snapTo = (index: number) => {
+  snapToIndex = (index: number) => {
     if (!this.props.enabledImperativeSnapping) {
       return
     }
@@ -729,23 +729,18 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
       val: number
       ind: number
     }> = props.snapPoints
-      .map(
-        (
-          s: number | string,
-          i: number
-        ): {
-          val: number
-          ind: number
-        } => {
-          if (typeof s === 'number') {
-            return { val: s, ind: i }
-          } else if (typeof s === 'string') {
-            return { val: BottomSheetBehavior.renumber(s), ind: i }
-          }
-
-          throw new Error(`Invalid type for value ${s}: ${typeof s}`)
+      .map((s: number | string, i: number): {
+        val: number
+        ind: number
+      } => {
+        if (typeof s === 'number') {
+          return { val: s, ind: i }
+        } else if (typeof s === 'string') {
+          return { val: BottomSheetBehavior.renumber(s), ind: i }
         }
-      )
+
+        throw new Error(`Invalid type for value ${s}: ${typeof s}`)
+      })
       .sort(({ val: a }, { val: b }) => b - a)
     if (state && state.snapPoints) {
       state.snapPoints.forEach(
@@ -759,7 +754,7 @@ export default class BottomSheetBehavior extends React.Component<Props, State> {
       snapPoints = state.snapPoints
     } else {
       snapPoints = sortedPropsSnapPoints.map(
-        p => new Value(sortedPropsSnapPoints[0].val - p.val)
+        (p) => new Value(sortedPropsSnapPoints[0].val - p.val)
       )
     }
 


### PR DESCRIPTION
Change the function snapTo to snapToIndex to avoid the confusion to what should be given as the parameter to the function. Applying the the clean code principles.